### PR TITLE
Only headless java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM renovate/base@sha256:9190172dd193475a94d7cfff61509c0d4bb740004b469b31c08a8d
 
 USER root
 
-RUN apt-get update && apt-get install -y default-jre && apt-get clean
+RUN apt-get update && apt-get install -y default-jre-headless && \
+    rm -rf /var/lib/apt/lists/*
 
 USER ubuntu
 


### PR DESCRIPTION
Only headless java is required, full jre add ui stuff, which is not working in docker